### PR TITLE
Feature/bodymasking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ serde = {version = "1.0.144", features = ["derive"]}
 serde_json = "1.0.85"
 
 [dev-dependencies]
+maplit = "1.0.2"
 pretty_assertions = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+# error handling
+thiserror = "1.0"
+
 # utils
 har = "0.7.1"
 once_cell = "1.14.0"

--- a/src/body_mask.rs
+++ b/src/body_mask.rs
@@ -38,7 +38,7 @@ impl BodyMask {
             for (field_name, _replacement_value) in string_field_names {
                 string_mask_regex.push_str(&format!(
                     r##"(?:("{}"): *)(".*?[^\\]")(?: *[, \n\r}}]?)|"##,
-                    field_name
+                    regex::escape(&field_name)
                 ));
             }
 
@@ -62,7 +62,7 @@ impl BodyMask {
             for (field_name, _replacement_value) in number_field_names {
                 number_mask_regex.push_str(&format!(
                     r##"(?:("{}"): *)(-?[0-9]+\.?[0-9]*)( *[, \n\r}}]?)|"##,
-                    field_name
+                    regex::escape(&field_name)
                 ));
             }
 
@@ -219,6 +219,15 @@ mod tests {
                 expected: r#"{"test": "testmask"}"#,
                 string_masks: hashmap! {
                     "test".to_string() => "testmask".to_string()
+                },
+                number_masks: hashmap! {},
+            },
+            Test {
+                name: "successfully masks body with complex field key",
+                body: r#"{"test\"hello\": ": "\",{abc}: .\""}"#,
+                expected: r#"{"test\"hello\": ": "testmask"}"#,
+                string_masks: hashmap! {
+                    r#"test\"hello\": "#.to_string() => "testmask".to_string()
                 },
                 number_masks: hashmap! {},
             },

--- a/src/body_mask.rs
+++ b/src/body_mask.rs
@@ -5,11 +5,6 @@ use thiserror::Error;
 
 use crate::util;
 
-struct CaptureMatch<'a> {
-    name: Cow<'a, str>,
-    value: Cow<'a, str>,
-}
-
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("invalid string field name: {0}")]
@@ -25,6 +20,8 @@ pub struct BodyMask {
 }
 
 impl BodyMask {
+    /// Create a new BodyMask struct using string_field_names and number_field_names
+    /// The regex will be compiled and stored in the struct so it can be used reused, for repeated calls
     pub fn try_new(
         string_field_names: HashMap<String, String>,
         number_field_names: HashMap<String, i32>,
@@ -83,7 +80,9 @@ impl BodyMask {
         })
     }
 
+    /// Will use the regexes stored in the struct to mask the body
     pub fn mask(&self, body: String) -> String {
+        // mask string fields
         let body = if let Some(string_mask_regex) = self.string_masks.as_ref() {
             string_mask_regex.replace_all(&body, |caps: &Captures| {
                 if let Some(field) = util::get_first_capture(caps) {
@@ -100,6 +99,7 @@ impl BodyMask {
             Cow::Owned(body)
         };
 
+        /// mask number fields
         let body = if let Some(number_mask_regex) = self.number_masks.as_ref() {
             number_mask_regex.replace_all(&body, |caps: &Captures| {
                 if let Some(field) = util::get_first_capture(caps) {
@@ -127,6 +127,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     struct Test {
+        #[allow(dead_code)]
         name: &'static str,
         body: &'static str,
         expected: &'static str,

--- a/src/body_mask.rs
+++ b/src/body_mask.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+
+use regex::Regex;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("invalid string field name: {0}")]
+    StringField(String),
+    #[error("invalid number field name: {0}")]
+    NumberField(String),
+}
+
+pub struct BodyMask {
+    string_masks: Vec<(Regex, String)>,
+    number_masks: Vec<(Regex, i32)>,
+}
+
+impl BodyMask {
+    pub fn try_new_with_custom_masks(
+        string_field_names: HashMap<String, String>,
+        number_field_names: HashMap<String, i32>,
+    ) -> Result<Self, Error> {
+        let mut string_masks: Vec<(Regex, String)> = Vec::with_capacity(string_field_names.len());
+        let mut number_masks: Vec<(Regex, i32)> = Vec::with_capacity(number_field_names.len());
+
+        // build up string field regexes
+        for (field_name, replacement_value) in string_field_names {
+            let regex_string = format!(r##"("{}": *)(".*?[^\\]")( *[, \n\r}}]?)"##, field_name);
+
+            let regex =
+                Regex::new(&regex_string).map_err(|_| Error::StringField(field_name.clone()))?;
+
+            string_masks.push((regex, replacement_value));
+        }
+
+        // build up number field regexes
+        for (field_name, replacement_value) in number_field_names {
+            let regex_string = format!(r##"("{}": *)(".*?[^\\]")( *[, \n\r}}]?)"##, field_name);
+
+            let regex =
+                Regex::new(&regex_string).map_err(|_| Error::NumberField(field_name.clone()))?;
+
+            number_masks.push((regex, replacement_value));
+        }
+
+        Ok(Self {
+            string_masks,
+            number_masks,
+        })
+    }
+}

--- a/src/body_mask.rs
+++ b/src/body_mask.rs
@@ -28,8 +28,9 @@ impl BodyMask {
         number_field_names: HashMap<String, i32>,
     ) -> Result<Self, Error> {
         let string_masks = if !string_field_names.is_empty() {
+            // estimate the size of the final regex string to minimize allocations
             let mut string_mask_regex = String::with_capacity(
-                (string_field_names.len() * 32) + (string_field_names.len() * 24),
+                (string_field_names.len() * 38) + (string_field_names.len() * 24),
             );
 
             // build up single regex from string field regexes
@@ -53,9 +54,9 @@ impl BodyMask {
         };
 
         let number_masks = if !number_field_names.is_empty() {
-            // build number masks regex
+            // estimate the size of the final regex string to minimize allocations
             let mut number_mask_regex = String::with_capacity(
-                (number_field_names.len() * 32) + (number_field_names.len() * 12),
+                (number_field_names.len() * 44) + (number_field_names.len() * 12),
             );
 
             for (field_name, _replacement_value) in number_field_names {

--- a/src/body_mask.rs
+++ b/src/body_mask.rs
@@ -34,7 +34,7 @@ impl BodyMask {
             string_masks.push((regex, replacement_value));
         }
 
-        // build up number field regexes
+        // build up number field regex's
         for (field_name, replacement_value) in number_field_names {
             let regex_string = format!(r##"("{}": *)(".*?[^\\]")( *[, \n\r}}]?)"##, field_name);
 
@@ -48,5 +48,44 @@ impl BodyMask {
             string_masks,
             number_masks,
         })
+    }
+
+    pub fn mask(&self, body: String) -> String {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use maplit::hashmap;
+    use pretty_assertions::assert_eq;
+
+    struct Test {
+        name: &'static str,
+        body: &'static str,
+        expected: &'static str,
+        string_masks: HashMap<String, String>,
+        number_masks: HashMap<String, i32>,
+    }
+
+    #[test]
+    fn run() {
+        let tests: Vec<Test> = vec![Test {
+            name: "successfully masks body with single string field",
+            body: r#"{"test": "test"}"#,
+            expected: r#"{"test": "testmask"}"#,
+            string_masks: hashmap! {
+                "test".to_string() => "testmask".to_string(),
+            },
+            number_masks: HashMap::new(),
+        }];
+
+        for test in tests {
+            assert_eq!(
+                test.expected,
+                BodyMask::try_new_with_custom_masks(test.string_masks, test.number_masks)
+                    .unwrap()
+                    .mask(test.body.to_string())
+            );
+        }
     }
 }

--- a/src/body_mask.rs
+++ b/src/body_mask.rs
@@ -99,7 +99,7 @@ impl BodyMask {
             Cow::Owned(body)
         };
 
-        /// mask number fields
+        // mask number fields
         let body = if let Some(number_mask_regex) = self.number_masks.as_ref() {
             number_mask_regex.replace_all(&body, |caps: &Captures| {
                 if let Some(field) = util::get_first_capture(caps) {

--- a/src/body_mask.rs
+++ b/src/body_mask.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
 use regex::{Captures, Regex};
+use std::fmt::Write as _;
 use thiserror::Error;
 
 use crate::util;
@@ -33,10 +34,11 @@ impl BodyMask {
 
             // build up single regex from string field regexes
             for (field_name, _replacement_value) in string_field_names {
-                string_mask_regex.push_str(&format!(
+                let _ = write!(
+                    string_mask_regex,
                     r##"(?:("{}"): *)(".*?[^\\]")(?: *[, \n\r}}]?)|"##,
                     regex::escape(&field_name)
-                ));
+                );
             }
 
             // drop the last "|"
@@ -57,10 +59,11 @@ impl BodyMask {
             );
 
             for (field_name, _replacement_value) in number_field_names {
-                number_mask_regex.push_str(&format!(
+                let _ = write!(
+                    number_mask_regex,
                     r##"(?:("{}"): *)(-?[0-9]+\.?[0-9]*)( *[, \n\r}}]?)|"##,
                     regex::escape(&field_name)
-                ));
+                );
             }
 
             // drop the last "|"

--- a/src/body_mask.rs
+++ b/src/body_mask.rs
@@ -1,7 +1,14 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
-use regex::Regex;
+use regex::{Captures, Regex};
 use thiserror::Error;
+
+use crate::util;
+
+struct CaptureMatch<'a> {
+    name: Cow<'a, str>,
+    value: Cow<'a, str>,
+}
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -12,8 +19,8 @@ pub enum Error {
 }
 
 pub struct BodyMask {
-    string_masks: Regex,
-    number_masks: Regex,
+    string_masks: Option<Regex>,
+    number_masks: Option<Regex>,
 }
 
 impl BodyMask {
@@ -21,40 +28,61 @@ impl BodyMask {
         string_field_names: HashMap<String, String>,
         number_field_names: HashMap<String, i32>,
     ) -> Result<Self, Error> {
-        let mut string_masks: Vec<(Regex, String)> = Vec::with_capacity(string_field_names.len());
-        let string_mask_regex = String::with_capacity(
-            (string_field_names.len() * 32) + (string_field_names.len() * 24),
-        );
+        let string_masks = if !string_field_names.is_empty() {
+            let mut string_mask_regex = String::with_capacity(
+                (string_field_names.len() * 32) + (string_field_names.len() * 24),
+            );
 
-        // build up single regex from string field regexes
-        for (field_name, replacement_value) in string_field_names {
-            string_mask_regex.push_str(&format!(
-                r##"("{}": *)(".*?[^\\]")( *[, \n\r}}]?)|"##,
-                field_name
-            ));
-        }
+            // // start string mask regex with a parent group
+            // string_mask_regex.push('(');
 
-        // drop the last "|"
-        string_mask_regex.pop();
+            // build up single regex from string field regexes
+            for (field_name, replacement_value) in string_field_names {
+                string_mask_regex.push_str(&format!(
+                    r##"(?:("{}"): *)(".*?[^\\]")(?: *[, \n\r}}]?)|"##,
+                    field_name
+                ));
+            }
 
-        let string_masks =
-            Regex::new(&string_mask_regex).map_err(|_| Error::StringField(string_mask_regex))?;
+            // drop the last "|" and close off parent capture group
+            string_mask_regex.pop();
+            // string_mask_regex.push(')');
 
-        // build number masks regex
-        let mut number_masks: Vec<(Regex, String)> = Vec::with_capacity(string_field_names.len());
-        let number_mask_regex = String::with_capacity(
-            (string_field_names.len() * 32) + (string_field_names.len() * 12),
-        );
+            let string_masks = Regex::new(&string_mask_regex)
+                .map_err(|_| Error::StringField(string_mask_regex))?;
 
-        for (field_name, replacement_value) in number_field_names {
-            number_mask_regex.push_str(&format!(
-                r##"("{}": *)(".*?[^\\]")( *[, \n\r}}]?)|"##,
-                field_name
-            ));
-        }
+            Some(string_masks)
+        } else {
+            None
+        };
 
-        let number_masks =
-            Regex::new(&number_mask_regex).map_err(|_| Error::NumberField(number_mask_regex))?;
+        let number_masks = if !number_field_names.is_empty() {
+            // build number masks regex
+            let mut number_mask_regex = String::with_capacity(
+                (number_field_names.len() * 32) + (number_field_names.len() * 12),
+            );
+
+            // start number mask regex with a parent group
+            number_mask_regex.push('(');
+
+            for (field_name, replacement_value) in number_field_names {
+                number_mask_regex.push_str(&format!(
+                    r##"("{}": *)(".*?[^\\]")( *[, \n\r}}]?)|"##,
+                    field_name
+                ));
+            }
+
+            // drop the last "|" and close off parent capture group
+            number_mask_regex.pop();
+            number_mask_regex.push(')');
+
+            let number_masks = Regex::new(&number_mask_regex)
+                .map_err(|_| Error::NumberField(number_mask_regex))?;
+
+            Some(number_masks)
+        } else {
+            None
+        };
 
         Ok(Self {
             string_masks,
@@ -62,7 +90,25 @@ impl BodyMask {
         })
     }
 
-    pub fn mask(&self, body: String) -> String {}
+    pub fn mask(&self, body: String) -> String {
+        let body = self
+            .string_masks
+            .as_ref()
+            .unwrap()
+            .replace_all(&body, |caps: &Captures| {
+                if let Some(field) = util::get_first_capture(caps) {
+                    format!(
+                        r#"{}: "testmask"{}"#,
+                        field,
+                        caps[0].chars().last().unwrap()
+                    )
+                } else {
+                    caps[0].to_string()
+                }
+            });
+
+        body.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -81,20 +127,32 @@ mod tests {
 
     #[test]
     fn run() {
-        let tests: Vec<Test> = vec![Test {
-            name: "successfully masks body with single string field",
-            body: r#"{"test": "test"}"#,
-            expected: r#"{"test": "testmask"}"#,
-            string_masks: hashmap! {
-                "test".to_string() => "testmask".to_string(),
+        let tests: Vec<Test> = vec![
+            Test {
+                name: "successfully masks body with single string field",
+                body: r#"{"test": "test"}"#,
+                expected: r#"{"test": "testmask"}"#,
+                string_masks: hashmap! {
+                    "test".to_string() => "testmask".to_string(),
+                },
+                number_masks: HashMap::new(),
             },
-            number_masks: HashMap::new(),
-        }];
+            Test {
+                name: "successfully masks body with multiple masking fields",
+                body: r#"{"test": "test", "another_test": "secret", "not_a_secret": "not a secret"}"#,
+                expected: r#"{"test": "testmask", "another_test": "testmask", "not_a_secret": "not a secret"}"#,
+                string_masks: hashmap! {
+                    "test".to_string() => "testmask".to_string(),
+                    "another_test".to_string() => "testmask".to_string(),
+                },
+                number_masks: HashMap::new(),
+            },
+        ];
 
         for test in tests {
             assert_eq!(
                 test.expected,
-                BodyMask::try_new_with_custom_masks(test.string_masks, test.number_masks)
+                BodyMask::try_new(test.string_masks, test.number_masks)
                     .unwrap()
                     .mask(test.body.to_string())
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+mod body_mask;
 mod path_hint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 mod body_mask;
 mod path_hint;
+mod util;

--- a/src/path_hint.rs
+++ b/src/path_hint.rs
@@ -17,7 +17,7 @@ pub fn normalize_path_hint(path_hint: String) -> String {
 
         // look through the captures and use the first non-empty capture
         if let Some(matched) = util::get_first_capture(caps) {
-            if caps[0].ends_with("/") {
+            if caps[0].ends_with('/') {
                 Cow::Owned(format!("{{{}}}/", matched))
             } else {
                 Cow::Owned(format!("{{{}}}", matched))

--- a/src/path_hint.rs
+++ b/src/path_hint.rs
@@ -26,16 +26,6 @@ pub fn normalize_path_hint(path_hint: String) -> String {
     .into_owned()
 }
 
-fn get_first_capture<'a>(caps: &'a Captures) -> Option<&'a str> {
-    for i in 1..caps.len() {
-        if let Some(c) = caps.get(i) {
-            return Some(c.as_str());
-        }
-    }
-
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/path_hint.rs
+++ b/src/path_hint.rs
@@ -3,6 +3,8 @@ use std::borrow::Cow;
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 
+use crate::util;
+
 static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\{(.*?:*.*?)\}/|:(.+?)/|:(.*)|\*"#).unwrap());
 
 pub fn normalize_path_hint(path_hint: String) -> String {
@@ -13,7 +15,7 @@ pub fn normalize_path_hint(path_hint: String) -> String {
         };
 
         // look through the captures and use the first non-empty capture
-        if let Some(matched) = get_first_capture(caps) {
+        if let Some(matched) = util::get_first_capture(caps) {
             if caps[0].ends_with("/") {
                 Cow::Owned(format!("{{{}}}/", matched))
             } else {

--- a/src/path_hint.rs
+++ b/src/path_hint.rs
@@ -7,6 +7,7 @@ use crate::util;
 
 static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\{(.*?:*.*?)\}/|:(.+?)/|:(.*)|\*"#).unwrap());
 
+/// Normalize the path hint given from different web frameworks to a the OpenAPI spec
 pub fn normalize_path_hint(path_hint: String) -> String {
     RE.replace_all(&path_hint, |caps: &Captures| {
         // if its a wildcard return capture replacement early

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,11 @@
+use regex::Captures;
+
+pub fn get_first_capture<'a>(caps: &'a Captures) -> Option<&'a str> {
+    for i in 1..caps.len() {
+        if let Some(c) = caps.get(i) {
+            return Some(c.as_str());
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
This PR contains the logic for body masking.

### What this PR has
- Masking all fields using 2 passes
- 1 regex is used for ALL string fields
- 1 regex is used for ALL number fields
- The regexes is only compiled once (This should be faster than creating a new regex during each masking pass)
- Same tests from the go-sdk, plus an additional test

### What this PR does not have
- Configuration for masking, this will be done in a later PR
- Checking `content-type`